### PR TITLE
Allow callers to provide a snapshot name

### DIFF
--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -12,6 +12,8 @@ class PublishingMetadata(object):
     Args:
         image_path (str): A file path or URL to the image
         image_name (str): The name of the image. Used as a primary identifier.
+        snapshot_name (str): The name of the snapshot. Derived from the image
+                             filename by default.
         description (str, optional): The description of the image
         container (str, optional): The name of the storage container for
                                    uploads
@@ -28,9 +30,10 @@ class PublishingMetadata(object):
     def __init__(self, image_path, image_name, description=None,
                  container=None, arch=None, virt_type=None,
                  root_device_name=None, volume_type=None,
-                 accounts=[], groups=[]):
+                 accounts=[], groups=[], snapshot_name=None):
         self.image_path = image_path
         self.image_name = image_name
+        self.snapshot_name = snapshot_name or self._default_snapshot_name
         self.description = description
         self.container = container
         self.arch = arch
@@ -41,7 +44,7 @@ class PublishingMetadata(object):
         self.groups = groups
 
     @property
-    def snapshot_name(self):
+    def _default_snapshot_name(self):
         return os.path.splitext(self.object_name)[0]
 
     @property

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='cloudimg',
-    version='1.0.0',
+    version='1.1.0',
     author='Alex Misstear',
     author_email='amisstea@redhat.com',
     description=('Services for building and releasing products in cloud '

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -24,6 +24,28 @@ class TestAWSPublishingMetadata(unittest.TestCase):
                           image_path='/some/fake/path/to/image.raw',
                           image_name='fakeimagename')
 
+    def test_default_snapshot_name(self):
+        """
+        Test that a snapshot name by default is derived from the image
+        filename.
+        """
+        metadata = AWSPublishingMetadata(image_path='/somedir/some-image.raw',
+                                         image_name='fakeimagename',
+                                         container='abcdef')
+
+        self.assertEqual(metadata.snapshot_name, 'some-image')
+
+    def test_explicit_snapshot_name(self):
+        """
+        Test that a snapshot name can be provided explicitly.
+        """
+        metadata = AWSPublishingMetadata(image_path='/somedir/some-image.raw',
+                                         image_name='fakeimagename',
+                                         snapshot_name='mysnapshot',
+                                         container='abcdef')
+
+        self.assertEqual(metadata.snapshot_name, 'mysnapshot')
+
 
 class TestAWSService(unittest.TestCase):
 


### PR DESCRIPTION
Snapshot name was previously always derived from image filename,
which resulted in one snapshot shared between multiple images
(e.g. images pushed from the same file with different billing
codes).

Keep this as the default behavior, but also let callers set the
snapshot name, so they can opt-out of this snapshot sharing
behavior as needed.