### PR TITLE
Update tox cov job to generate xml coverage report

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -36,4 +36,4 @@ deps=
 	pytest-cov
 usedevelop=true
 commands=
-	pytest --cov-report=html --cov=cloudimg {posargs}
+	pytest --cov-report=html --cov-report=xml --cov=cloudimg {posargs}


### PR DESCRIPTION
Codecov action to upload coverage report was upgraded to v2.
However, the reports were not uploaded correctly as v2 accepts
coverage reports in xml format only. Hence, updating the cov
job in tox to generate coverage reports in xml instead of html.