### PR TITLE
Add snapshot creation permissions on snapshot creation

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -380,6 +380,7 @@ class AWSService(BaseService):
                     log.info('Object already exists')
 
                 snapshot = self.import_snapshot(obj, metadata.snapshot_name)
+                self.share_snapshot(snapshot, metadata.snapshot_account_ids)
             else:
                 log.info('Snapshot already exists with id: %s', snapshot.id)
 
@@ -546,3 +547,24 @@ class AWSService(BaseService):
         }
 
         image.modify_attribute(**attrs)
+
+    def share_snapshot(self, snapshot, accounts):
+        """
+        Shares a snapshot with other user accounts.
+
+        Args:
+            snapshot (Snapshot): An EC2 Snapshot
+            accounts (list, optional): Names of accounts to share with
+        """
+        if not accounts:
+            return
+
+        log.info('Sharing %s with accounts: %s', snapshot.name, accounts)
+
+        attrs = {
+            'Attribute': 'createVolumePermission',
+            'CreateVolumePermission': {
+                'Add': [{'UserId': u} for u in accounts]
+            }
+        }
+        snapshot.modify_attribute(**attrs)

--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -25,15 +25,19 @@ class PublishingMetadata(object):
                                    the image
         groups (list, optional): Groups which will have permission to use the
                                  image
+        snapshot_account_ids (list, optional): Accounts which will have
+                                            permission to create the snapshot
     """
 
     def __init__(self, image_path, image_name, description=None,
                  container=None, arch=None, virt_type=None,
                  root_device_name=None, volume_type=None,
-                 accounts=[], groups=[], snapshot_name=None):
+                 accounts=[], groups=[], snapshot_name=None,
+                 snapshot_account_ids=None):
         self.image_path = image_path
         self.image_name = image_name
         self.snapshot_name = snapshot_name or self._default_snapshot_name
+        self.snapshot_account_ids = snapshot_account_ids
         self.description = description
         self.container = container
         self.arch = arch

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -228,6 +228,21 @@ class TestAWSService(unittest.TestCase):
         self.svc.share_image(image, accounts=accounts, groups=groups)
         image.modify_attribute.assert_not_called()
 
+    def test_share_snapshot(self):
+        accounts = ['account1', 'account2']
+
+        snapshot = MagicMock()
+
+        self.svc.share_snapshot(snapshot, accounts=accounts, )
+        snapshot.modify_attribute.assert_called_once_with(
+            Attribute="createVolumePermission",
+            CreateVolumePermission={
+                'Add': [
+                    {'UserId': 'account1'},
+                    {'UserId': 'account2'},
+                ]
+            })
+
     @patch('cloudimg.aws.AWSService.wait_for_import_snapshot_task')
     def test_import_snapshot(self, mock_wait):
         snapshot = mock_wait.return_value = MagicMock()


### PR DESCRIPTION
When an image gets pushed a snapshot will be created if one doesn't already exists. The current workflow doesn't grant any 
"CreateVolumePermission" permissions, though it is expected certain accounts should have them. 

This change adds a call to AWS to set the permissions of a snapshot when it gets created. It uses the same API with a similar call to how the 'LaunchPermission' is granted for images. This change will be used by pubtools-ami, which will pass a list of account IDs which should have the "CreateVolumePermission" permission.