### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -3,20 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Install RPM
-        run: sudo apt-get install -y rpm
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27
   py38:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -10,12 +10,12 @@ A library for uploading and publishing disk images on various clouds
 
 ## Development
 
-It's best to develop with python 2.6 since that is the minimum supported
+It's best to develop with python 3.6 since that is the minimum supported
 version and tends to have the most restrictive features.
 
 ```
 # Setup a virtual environment
-virtualenv -p python2.6 venv
+virtualenv -p python3.6 venv
 source venv/bin/activate
 
 # Install the package for development

--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -1,11 +1,8 @@
 from datetime import datetime, timedelta
 import logging
 import os
-try:
-    from time import monotonic
-except ImportError:
-    # Python < 3.3
-    from monotonic import monotonic
+
+from time import monotonic
 
 import attr
 

--- a/constraints-legacy.txt
+++ b/constraints-legacy.txt
@@ -1,4 +1,0 @@
-boto3==1.4.6
-azure-storage-blob==12.9.0
-azure-mgmt-storage==19.0.0
-monotonic==1.6

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,16 @@ setup(
     license='GPLv3',
     url='https://github.com/release-engineering/cloudimg',
     packages=find_packages(),
+    python_requires=">=3.6",
+    classifiers=[
+        "Intended Audience :: Developers",
+        "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
+        "Programming Language :: Python",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8"
+    ],
     install_requires=[
         'azure-storage-blob',
         'azure-mgmt-storage',

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -1,11 +1,7 @@
 from copy import deepcopy
 import unittest
 
-try:
-    from unittest.mock import MagicMock, patch
-except ImportError:
-    # Python <= 2.7
-    from mock import MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 from cloudimg.aws import (
     AWSService, AWSPublishingMetadata, ClientError,

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -1,10 +1,7 @@
 from tempfile import NamedTemporaryFile
 import unittest
-try:
-    from unittest.mock import MagicMock, patch, call, ANY
-except ImportError:
-    # Python <= 2.7
-    from mock import MagicMock, patch, call, ANY
+
+from unittest.mock import MagicMock, patch, call, ANY
 
 from cloudimg.ms_azure import (
     AzurePublishingMetadata,

--- a/tox.ini
+++ b/tox.ini
@@ -1,19 +1,9 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,py37,lint,py38
+envlist = py36,py37,lint,py38
 
 [testenv]
 deps = -rrequirements-test.txt
 commands = py.test -v {posargs}
-
-[testenv:py27]
-# In general, most test envs are allowed to use latest
-# installable versions of deps from PyPI.
-# Here we ensure there is at least one test env covering
-# the oldest versions of certain dependencies we want to
-# support.
-deps =
-	-rrequirements-test.txt
-	-cconstraints-legacy.txt
 
 [testenv:lint]
 skip_install = true


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.