### PR TITLE
Allow AzureService to upload uncompressed LZMA

### DIFF
--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -413,21 +413,18 @@ class AzureService(BaseService):
 
         log.info('Uploading %s to container %s', image_path, container_name)
         log.info('Uploading %s with name %s', image_path, object_name)
-        if image_path.startswith("http:") or image_path.startswith("https:"):
-            blob_client.upload_blob_from_url(source_url=image_path, **kwargs)
-        else:
-            with open_func(image_path, "rb") as data:
-                # we need to pass the lenght to upload_blob as it will try to
-                # guess the length of LZMAFile and it get the incorrect value,
-                # which is the size of compressed file.
-                bytes_count = data.seek(0, os.SEEK_END)
-                data.seek(0)
-                log.debug("Upload size: %d bytes", bytes_count)
-                blob_client.upload_blob(
-                    data=data,
-                    length=bytes_count,
-                    **kwargs
-                )
+        with open_func(image_path, "rb") as data:
+            # we need to pass the lenght to upload_blob as it will try to
+            # guess the length of LZMAFile and it get the incorrect value,
+            # which is the size of compressed file.
+            bytes_count = data.seek(0, os.SEEK_END)
+            data.seek(0)
+            log.debug("Upload size: %d bytes", bytes_count)
+            blob_client.upload_blob(
+                data=data,
+                length=bytes_count,
+                **kwargs
+            )
         log.info(str(self._upload_progress))
         log.info('Successfully uploaded %s', image_path)
         return blob_client

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -503,6 +503,12 @@ class TestAzureService(unittest.TestCase):
         mock_blob.upload_blob.side_effect = mock_callback
 
         with NamedTemporaryFile() as tmpfile:
+            # Write some testing data
+            tmpfile.seek(1020)
+            tmpfile.write(b"1234")
+            tmpfile.flush()
+
+            # Test the upload
             res = self.svc.upload_to_container(
                     image_path=tmpfile.name,
                     container_name=self.md.container,
@@ -518,6 +524,7 @@ class TestAzureService(unittest.TestCase):
         mock_blob.exists.assert_called_once()
         mock_blob.upload_blob.assert_called_once_with(
             data=ANY,
+            length=1024,
             tags=self.md.tags,
             max_concurrency=self.svc.UPLOAD_MAX_CONCURRENCY,
             raw_response_hook=mock_callback,

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -450,45 +450,6 @@ class TestAzureService(unittest.TestCase):
     @patch('cloudimg.ms_azure.AzureService.upload_callback')
     @patch('cloudimg.ms_azure.AzureService.are_tags_present')
     @patch('cloudimg.ms_azure.AzureService.get_container_by_name')
-    def test_upload_to_container_blob_from_https(self,
-                                                 mock_get,
-                                                 mock_are_tags,
-                                                 mock_callback):
-        mock_blob = MagicMock()
-        mock_blob.exists.return_value = False
-        mock_cc = MagicMock()
-        mock_cc.get_blob_client.return_value = mock_blob
-        mock_get.return_value = mock_cc
-        mock_are_tags.return_value = False
-        mock_blob.upload_blob_from_url.side_effect = mock_callback
-        mock_blob.upload_blob.side_effect = mock_callback
-
-        res = self.svc.upload_to_container(
-                  image_path='https://foo/bar',
-                  container_name=self.md.container,
-                  object_name=self.md.object_name,
-                  tags=self.md.tags
-              )
-
-        mock_get.assert_called_once_with(name=self.md.container, create=True)
-        mock_are_tags.assert_called_once_with(mock_cc, self.md.tags)
-        mock_cc.get_blob_client.assert_called_once_with(
-            blob=self.md.object_name
-        )
-        mock_blob.exists.assert_called_once()
-        mock_blob.upload_blob_from_url.assert_called_once_with(
-            source_url='https://foo/bar',
-            tags=self.md.tags,
-            max_concurrency=self.svc.UPLOAD_MAX_CONCURRENCY,
-            raw_response_hook=mock_callback,
-        )
-        mock_blob.upload_blob.assert_not_called()
-        mock_callback.assert_called_once()
-        self.assertEqual(res, mock_blob)
-
-    @patch('cloudimg.ms_azure.AzureService.upload_callback')
-    @patch('cloudimg.ms_azure.AzureService.are_tags_present')
-    @patch('cloudimg.ms_azure.AzureService.get_container_by_name')
     def test_upload_to_container_blob_from_storage(self,
                                                    mock_get,
                                                    mock_are_tags,
@@ -499,7 +460,6 @@ class TestAzureService(unittest.TestCase):
         mock_cc.get_blob_client.return_value = mock_blob
         mock_get.return_value = mock_cc
         mock_are_tags.return_value = False
-        mock_blob.upload_blob_from_url.side_effect = mock_callback
         mock_blob.upload_blob.side_effect = mock_callback
 
         with NamedTemporaryFile() as tmpfile:
@@ -529,7 +489,6 @@ class TestAzureService(unittest.TestCase):
             max_concurrency=self.svc.UPLOAD_MAX_CONCURRENCY,
             raw_response_hook=mock_callback,
         )
-        mock_blob.upload_blob_from_url.assert_not_called()
         mock_callback.assert_called_once()
         self.assertEqual(res, mock_blob)
 


### PR DESCRIPTION
Since it's not possible to use a compressed VHD image in Azure Compute we need to decompress it before uploading.

This PR changes the `AzureService.upload_to_container` to automatically detect a LZMA compressed file (.xz) and send the decompressed bytes when uploading.

In order to properly send the uncompressed data we need to specify the length of the original file in bytes. By passing the length we also optimize the upload for the uncompressed files so it's useful for both cases.