### PR TITLE
Pin bandit version

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -4,3 +4,4 @@ flake8<3.0.0; python_version <= '2.6'
 flake8; python_version > '2.6'
 mock; python_version <= '2.7'
 pytest
+bandit==1.7.5; python_version > '3'

--- a/tox.ini
+++ b/tox.ini
@@ -18,9 +18,9 @@ commands=
 	pytest --cov-report=html --cov-report=xml --cov=cloudimg {posargs}
 
 [testenv:py3-bandit-exitzero]
-deps = bandit
+deps = -rrequirements-test.txt
 commands = bandit -r . -l --exclude './.tox' --exit-zero
 
 [testenv:py3-bandit]
-deps = bandit
+deps = -rrequirements-test.txt
 commands = bandit -r . -ll --exclude './.tox'


### PR DESCRIPTION
We pin the version of Bandit SAST tool to make the CI tests more predictable. If we used the latest version available without pinning it, the CI tests could start failing on new Bandit version without any changes in our codebase.

We pin the Bandit version by adding version requirement to requirements-test.txt