### PR TITLE
Search for uncompressed image on S3

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -432,7 +432,8 @@ class AWSService(BaseService):
             # Stream the decompression to the container file
             # Can take a few minutes to load into memory
             callback = UploadProgress(container_name, object_name)
-            log.info("Processing a LZMA compressed file: %s.", object_name)
+            log.info("Processing a LZMA compressed file: %s.",
+                     os.path.basename(image_path))
             with lzma.open(image_path, "rb") as data:
                 self.s3.meta.client.upload_fileobj(data,
                                                    container_name,

--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -420,7 +420,7 @@ class AWSService(BaseService):
             resp.raise_for_status()
             stream = resp.iter_content(chunk_size)
             callback = UploadProgress(container_name, object_name)
-            if object_name.endswith(".xz"):
+            if image_path.endswith(".xz"):
                 raise NotImplementedError(
                     "LZMA decompression is not implemented "
                     "for S3 content from an HTTP source")
@@ -428,10 +428,9 @@ class AWSService(BaseService):
                                                container_name,
                                                object_name,
                                                Callback=callback)
-        elif object_name.endswith(".xz"):
+        elif image_path.endswith(".xz"):
             # Stream the decompression to the container file
             # Can take a few minutes to load into memory
-            object_name = object_name.rstrip(".xz")
             callback = UploadProgress(container_name, object_name)
             log.info("Processing a LZMA compressed file: %s.", object_name)
             with lzma.open(image_path, "rb") as data:

--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -56,7 +56,7 @@ class PublishingMetadata(object):
 
     @property
     def object_name(self):
-        return os.path.basename(self.image_path)
+        return os.path.basename(self.image_path).rstrip(".xz")
 
 
 class DeleteMetadata(object):

--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -379,9 +379,9 @@ class AzureService(BaseService):
 
         # Azure can't handle compressed images on marketplaces so we need to
         # send the decompressed data to its storage account.
-        if object_name.endswith(".xz"):
-            log.info("Processing a LZMA compressed file: %s.", object_name)
-            object_name = object_name.rstrip(".xz")
+        if image_path.endswith(".xz"):
+            log.info("Processing a LZMA compressed file: %s.",
+                     os.path.basename(image_path))
             open_func = lzma.open
         else:
             open_func = open


### PR DESCRIPTION
Since the `AWSService` will uncompress any `.xz` (LZMA) files before uploading we need to search for it as uncompressed on S3.

This commit patches the `object_name` before sending it to `get_object_by_name` so the file name matches the expected upload.

Refers to EXDSP-2097