### PR TITLE
Azure bugfix: prevent null response from upload

### DIFF
--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -400,7 +400,11 @@ class AzureService(BaseService):
                     container_client.container_name
                 )
             )
-            return
+            filtered = self.filter_object_by_tags(tags)
+            return self.get_object_by_name(
+                        container=filtered.container_name,
+                        name=filtered.name,
+                   )
 
         # Upload to container and tag image
         blob_client = container_client.get_blob_client(blob=object_name)
@@ -410,7 +414,10 @@ class AzureService(BaseService):
                 object_name,
                 container_name,
             )
-            return
+            return self.get_object_by_name(
+                        container=container_name,
+                        name=object_name,
+                   )
 
         log.info('Uploading %s to container %s', image_path, container_name)
         log.info('Uploading %s with name %s', image_path, object_name)


### PR DESCRIPTION
This commit changes the `AzureService.upload_to_container` to always return the blob whenever its uploaded or not.

In the previous versions whenever the blob exist in container it would return a null response, however it would break the `publish` method since it expects a `blob` response from `upload_to_container` and would crash into the last log line before `return blob.get_blob_properties` which would also fail since it may receive a null value.