### PR TITLE
Azure: search by object_name instead of image_name

### DIFF
--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -449,16 +449,16 @@ class AzureService(BaseService):
         """
         log.info(
             'Searching for image: %s in container %s',
-            metadata.image_name,
+            metadata.object_name,
             metadata.container,
         )
         blob = self.get_object_by_name(
                     container=metadata.container,
-                    name=metadata.image_name,
+                    name=metadata.object_name,
                 )
 
         if not blob:
-            log.info('Image does not exist: %s', metadata.image_name)
+            log.info('Image does not exist: %s', metadata.object_name)
             log.info('Searching for tags: %s', metadata.tags)
 
             filtered_blob = self.filter_object_by_tags(metadata.tags)

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -508,7 +508,7 @@ class TestAzureService(unittest.TestCase):
 
         mock_get_obj.assert_called_once_with(
             container=self.md.container,
-            name=self.md.image_name,
+            name=self.md.object_name,
         )
         mock_filter_by_tags.assert_called_once_with(self.md.tags)
         mock_upload.assert_called_once_with(
@@ -532,7 +532,7 @@ class TestAzureService(unittest.TestCase):
         mock_get_obj.side_effect = [None, mock_blob]
         mock_filter_by_tags.return_value = mock_filtered
         calls = [
-            call(container=self.md.container, name=self.md.image_name),
+            call(container=self.md.container, name=self.md.object_name),
             call(container=self.md.container, name=self.md.object_name),
         ]
 
@@ -560,7 +560,7 @@ class TestAzureService(unittest.TestCase):
 
         mock_get_obj.assert_called_once_with(
             container=self.md.container,
-            name=self.md.image_name
+            name=self.md.object_name
         )
         mock_filter_by_tags.assert_not_called()
         mock_upload.assert_not_called()


### PR DESCRIPTION
This commit changes the `AzureService.publish` to search for the uploaded image first by using its `object_name` instead of `image_name` in order to properly identify the uploaded blob.