### PR TITLE
Add ability to specify bootmode [RHELDST-18235]

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -49,6 +49,10 @@ class AWSPublishingMetadata(PublishingMetadata):
 
         super(AWSPublishingMetadata, self).__init__(*args, **kwargs)
 
+        # Convert uefi_support bool into AWS specific values
+        self.boot_mode = "uefi-preferred" if self.uefi_support \
+            else "legacy-bios"
+
         assert self.container, 'A container must be defined'
 
 
@@ -642,7 +646,8 @@ class AWSService(BaseService):
             BlockDeviceMappings=block_device_mapping,
             EnaSupport=metadata.ena_support,
             SriovNetSupport=metadata.sriov_net_support,
-            BillingProducts=metadata.billing_products
+            BillingProducts=metadata.billing_products,
+            BootMode=metadata.boot_mode
         )
         if metadata.tags:
             self.tag_image(image, metadata.tags)

--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -22,6 +22,7 @@ class PublishingMetadata(object):
         virt_type (str, optional): Ex. hvm, paravirtual
         root_device_name (str, optional): Ex. /dev/sda1
         volume_type (str, optional): Ex. standard, gp2
+        uefi_support (Bool, optional): Whether the image supports UEFI boot
         accounts (list, optional): Accounts which will have permission to use
                                    the image
         groups (list, optional): Groups which will have permission to use the
@@ -35,7 +36,7 @@ class PublishingMetadata(object):
                  container=None, arch=None, virt_type=None,
                  root_device_name=None, volume_type=None,
                  accounts=[], groups=[], snapshot_name=None,
-                 snapshot_account_ids=None, tags=None):
+                 snapshot_account_ids=None, tags=None, uefi_support=None):
         self.image_path = image_path
         self.image_name = image_name
         self.snapshot_name = snapshot_name or self._default_snapshot_name
@@ -46,6 +47,7 @@ class PublishingMetadata(object):
         self.virt_type = virt_type
         self.root_device_name = root_device_name
         self.volume_type = volume_type
+        self.uefi_support = uefi_support
         self.accounts = accounts
         self.groups = groups
         self.tags = tags

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -611,7 +611,8 @@ class TestAWSService(unittest.TestCase):
             BlockDeviceMappings=block_device_mapping,
             EnaSupport=self.md.ena_support,
             SriovNetSupport=self.md.sriov_net_support,
-            BillingProducts=self.md.billing_products
+            BillingProducts=self.md.billing_products,
+            BootMode=self.md.boot_mode
         )
         tag_image.assert_not_called()
         self.assertEqual(res, "fakeimg")


### PR DESCRIPTION
From RHEL 8.9 and RHEL 9.3 onwards UEFI will be available. The boot mode must be specified for AMI images to make use of the change. This change adds the boot mode to the metadata and image sharing call. I've kept the value as a boolean until this point since AWS requires specific string values for different boot types.