### PR TITLE
Fix legacy bootmode enum to match pushsource

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -34,7 +34,7 @@ class AWSBootMode(enum.Enum):
     uefi = "uefi"
     """Support UEFI only."""
 
-    bios = "legacy-bios"
+    legacy = "legacy-bios"
     """Support BIOS only."""
 
     hybrid = "uefi-preferred"
@@ -76,7 +76,7 @@ class AWSPublishingMetadata(PublishingMetadata):
             self.uefi_support is not None
         ):
             self.boot_mode = AWSBootMode.hybrid if self.uefi_support \
-                             else AWSBootMode.bios
+                             else AWSBootMode.legacy
 
         assert self.container, 'A container must be defined'
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -630,7 +630,7 @@ class TestAWSService(unittest.TestCase):
     @patch('cloudimg.aws.AWSService.tag_image')
     def test_register_image_boot_mode(self, tag_image):
         self.mock_register_image.return_value = "fakeimg"
-        boot_modes = ["uefi", "bios", "hybrid"]
+        boot_modes = ["uefi", "legacy", "hybrid"]
 
         for bmode in boot_modes:
             self.md.boot_mode = AWSBootMode[bmode]
@@ -669,7 +669,7 @@ class TestAWSService(unittest.TestCase):
         self.mock_register_image.return_value = "fakeimg"
         uefi_support_map = {
             True: AWSBootMode.hybrid,
-            False: AWSBootMode.bios,
+            False: AWSBootMode.legacy,
         }
 
         for bool_value, b_mode in uefi_support_map.items():


### PR DESCRIPTION
Fixes the enum for bootmode to match the expected output of Pushsource

Related to EXDSP-2127