### PR TITLE
Add tag while uploading rhcos images

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -658,7 +658,7 @@ class AWSService(BaseService):
 
         return snapshot
 
-    def copy_ami(self, image_id, image_name, image_region,):
+    def copy_ami(self, image_id, image_name, image_region, tags):
         """
         Create copy of an AMI.
 
@@ -666,14 +666,24 @@ class AWSService(BaseService):
             image_id (str): AMI Id of the image to copy
             name (str): Name of new image
             region(str): Region for new Image.
+            tags(list, optional): Tags to be associated with new ami.
 
         Returns:
             Dict with Image_id of the newly created AMI and requests_id
         """
+        if tags:
+            tag_specifications = [{
+                "ResourceType": "image",
+                "Tags": self._get_tagdict(tags)
+                }]
+        else:
+            tag_specifications = []
+
         resp = self.ec2.meta.client.copy_image(
             SourceImageId=image_id,
             Name=image_name,
             SourceRegion=image_region,
+            TagSpecifications=tag_specifications
             )
         return resp
 

--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -489,7 +489,10 @@ class AzureService(BaseService):
         if is_image_path_an_url(urlparse(image_path)):
             log.info('Copying %s to container %s', image_path, container_name)
             blob_client.start_copy_from_url(
-                source_url=image_path, metadata={}, incremental_copy=False
+                source_url=image_path,
+                metadata={},
+                incremental_copy=False,
+                tags=tags
             )
             return self._get_blob_copy_status(blob_client)
 

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -363,13 +363,32 @@ class TestAWSService(unittest.TestCase):
 
     def test_copy_ami(self):
         self.mock_copy_ami.return_value = {
-            'ImageId': 'ami-08',
-            'ResponseMetadata': {'RequestId': 'cf32',  'server': 'AmazonEC2'}}
-        copy_ami_result = self.svc.copy_ami("ami-01", "rhcos", "us-east-1")
-        self.assertEqual(copy_ami_result['ImageId'], "ami-08")
-        self.mock_copy_ami.assert_called_once_with(
-            SourceImageId='ami-01', Name='rhcos', SourceRegion='us-east-1'
-        )
+            "ImageId": "ami-08",
+            "ResponseMetadata": {"RequestId": "cf32", "server": "AmazonEC2"},
+        }
+        sub_tests_params = [
+            (
+                {"key": "value"},
+                [{"ResourceType": "image",
+                  "Tags": [{"Key": "key", "Value": "value"}]}],
+            ),
+            (None, []),
+        ]
+        for tags, tags_specification in sub_tests_params:
+            with self.subTest(tags=tags,
+                              tags_specification=tags_specification):
+
+                copy_ami_result = self.svc.copy_ami(
+                    "ami-01", "rhcos", "us-east-1", tags
+                )
+                self.assertEqual(copy_ami_result["ImageId"], "ami-08")
+
+                self.mock_copy_ami.assert_called_with(
+                    SourceImageId="ami-01",
+                    Name="rhcos",
+                    SourceRegion="us-east-1",
+                    TagSpecifications=tags_specification,
+                )
 
     def test_share_image(self):
         accounts = ['account1', 'account2']

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -549,7 +549,8 @@ class TestAzureService(unittest.TestCase):
         mock_blob_client.start_copy_from_url.assert_called_once_with(
             source_url="https://example.com/rhcos-azure.x86_64.vhd",
             metadata={},
-            incremental_copy=False)
+            incremental_copy=False,
+            tags=self.md.tags)
 
         mock_are_tags_present.assert_called_once_with(
             mock_container_client, self.md.tags
@@ -587,7 +588,8 @@ class TestAzureService(unittest.TestCase):
         mock_blob_client.start_copy_from_url.assert_called_once_with(
             source_url="https://example.com/rhcos-azure.x86_64.vhd",
             metadata={},
-            incremental_copy=False)
+            incremental_copy=False,
+            tags=self.md.tags)
 
         mock_are_tags_present.assert_called_once_with(
             mock_container_client, self.md.tags


### PR DESCRIPTION
This merge request enables adding tags to images being uploaded to aws and azure. @JAVGan @jajreidy @rohanpm PTAL.