### PR TITLE
Adds removing image object in s3 to delete.

### DIFF
--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -73,15 +73,25 @@ class DeleteMetadata(object):
         snapshot_name (str, optional): The name of the snapshot.
         skip_snapshot (bool, optional): If true, deletion of snapshot is
                                         skipped. Default=False.
+        container (str, optional): Container that the s3 object was
+                                        uploaded to.
+        image_path (str, optional): Path to object originally uploaded.
     """
     def __init__(self, image_id, image_name=None, snapshot_id=None,
-                 snapshot_name=None, skip_snapshot=False):
+                 snapshot_name=None, skip_snapshot=False,
+                 container=None, image_path=""):
 
         self.image_id = image_id
         self.image_name = image_name
         self.snapshot_id = snapshot_id
         self.snapshot_name = snapshot_name
         self.skip_snapshot = skip_snapshot
+        self.container = container
+        self.image_path = image_path
+
+    @property
+    def object_name(self):
+        return os.path.basename(self.image_path).rstrip(".xz")
 
 
 class BaseService(object):

--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -137,15 +137,13 @@ class AzurePublishingMetadata(PublishingMetadata):
 class AzureDeleteMetadata(DeleteMetadata):
     """The required information to delete a blob on Azure."""
 
-    def __init__(self, container, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
         # Set the image NAME as the ID for Azure as both are redundant
         # for this marketplace.
         if not kwargs.get("image_name"):
             kwargs.update({"image_name": kwargs.get("image_id")})
 
         super(AzureDeleteMetadata, self).__init__(*args, **kwargs)
-
-        self.container = container
 
 
 class AzureService(BaseService):


### PR DESCRIPTION
This allows the option to delete an image object in s3 when the delete function is used. Adding the container and the path to file to the AWSDeleteMetadata will trigger searching for and deleting the object. This is optional and shouldn't break code in other implementations.

References SPSTRAT-399