### PR TITLE
Allow disabling the search for tags fallback

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -541,6 +541,15 @@ class AWSService(BaseService):
 
         return obj
 
+    def _find_image(self, image_name, search_tags):
+        image = self.get_image_by_name(image_name)
+        if not image and search_tags:
+            log.info("Searching for image %s by tags: %s",
+                     image_name,
+                     search_tags)
+            image = self.get_image_by_tags(search_tags)
+        return image
+
     @log_request_id
     def publish(self, metadata):
         """
@@ -559,10 +568,10 @@ class AWSService(BaseService):
             An EC2 Image
         """
         log.info('Searching for image: %s', metadata.image_name)
-        image = (
-            self.get_image_by_name(metadata.image_name) or
-            self.get_image_by_tags(metadata.tags)
-        )
+        search_tags = None
+        if metadata.search_tags:
+            search_tags = metadata.tags
+        image = self._find_image(metadata.image_name, search_tags)
 
         if not image:
             log.info('Image does not exist: %s', metadata.image_name)

--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -30,13 +30,16 @@ class PublishingMetadata(object):
         snapshot_account_ids (list, optional): Accounts which will have
                                             permission to create the snapshot
         tags (dict, optional): Tags to be applied to the image.
+        search_tags (bool, optional): Whether to find the image for tags (True)
+        when it's not found by name or not (False). Defaults to True.
     """
 
     def __init__(self, image_path, image_name, description=None,
                  container=None, arch=None, virt_type=None,
                  root_device_name=None, volume_type=None,
                  accounts=[], groups=[], snapshot_name=None,
-                 snapshot_account_ids=None, tags=None, uefi_support=None):
+                 snapshot_account_ids=None, tags=None, uefi_support=None,
+                 search_tags=True):
         self.image_path = image_path
         self.image_name = image_name
         self.snapshot_name = snapshot_name or self._default_snapshot_name
@@ -51,6 +54,7 @@ class PublishingMetadata(object):
         self.accounts = accounts
         self.groups = groups
         self.tags = tags
+        self.search_tags = search_tags
 
     @property
     def _default_snapshot_name(self):

--- a/cloudimg/ms_azure.py
+++ b/cloudimg/ms_azure.py
@@ -540,12 +540,15 @@ class AzureService(BaseService):
 
         if not blob:
             log.info('Image does not exist: %s', metadata.object_name)
-            log.info('Searching for tags: %s', metadata.tags)
-
-            filtered_blob = self.filter_object_by_tags(metadata.tags)
+            filtered_blob = None
+            if metadata.search_tags:
+                log.info('Searching for tags: %s', metadata.tags)
+                filtered_blob = self.filter_object_by_tags(metadata.tags)
 
             if not filtered_blob:
-                log.error("Image not found with tags \"%s\"", metadata.tags)
+                if metadata.search_tags:
+                    log.error("Image not found with tags \"%s\"",
+                              metadata.tags)
                 blob = self.upload_to_container(
                     image_path=metadata.image_path,
                     container_name=metadata.container,

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -622,6 +622,35 @@ class TestAzureService(unittest.TestCase):
     @patch('cloudimg.ms_azure.AzureService.upload_to_container')
     @patch('cloudimg.ms_azure.AzureService.filter_object_by_tags')
     @patch('cloudimg.ms_azure.AzureService.get_object_by_name')
+    def test_publish_without_search_tags(self,
+                                         mock_get_obj,
+                                         mock_filter_by_tags,
+                                         mock_upload):
+        mock_blob = MagicMock()
+        mock_blob.get_blob_properties.return_value = "props"
+        mock_get_obj.return_value = None
+        mock_filter_by_tags.return_value = None
+        mock_upload.return_value = mock_blob
+        self.md.search_tags = False
+
+        res = self.svc.publish(self.md)
+
+        mock_filter_by_tags.assert_not_called()
+        mock_get_obj.assert_called_once_with(
+            container=self.md.container,
+            name=self.md.object_name,
+        )
+        mock_upload.assert_called_once_with(
+            image_path=self.md.image_path,
+            container_name=self.md.container,
+            object_name=self.md.object_name,
+            tags=self.md.tags,
+        )
+        self.assertEqual(res, "props")
+
+    @patch('cloudimg.ms_azure.AzureService.upload_to_container')
+    @patch('cloudimg.ms_azure.AzureService.filter_object_by_tags')
+    @patch('cloudimg.ms_azure.AzureService.get_object_by_name')
     def test_publish_tag_found(self, mock_get_obj, mock_filter_by_tags,
                                mock_upload):
         mock_blob = MagicMock()


### PR DESCRIPTION
When searching for the image existence, by defaut, the library first search it from its name and if not found by the tags. However, there are certain situations which the latter search (tags) may not be executed.

This commit preserves the default experience of the library while allowing to disable the tags search fallback wheenver the new publishing metadata attribute `search_tags` is set to `False`.

Refers to SPSTRAT-451