### PR TITLE
AWS: Allow setting tags to snapshots or AMIs only

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -83,6 +83,12 @@ class AWSPublishingMetadata(PublishingMetadata):
         billing_products (list, optional): Billing product identifiers
 
         boot_mode (str, optional): The boot mode for booting up the AMI on EC2.
+
+        snapshot_tags (dict, optional): Tags to be applied to the snapshot
+        import only.
+
+        ami_tags (dict, optional): Tags to be applied to the registered AMI
+        only.
     """
 
     def __init__(self, *args, **kwargs):
@@ -91,6 +97,8 @@ class AWSPublishingMetadata(PublishingMetadata):
         self.billing_products = kwargs.pop('billing_products', None)
         bmode_str = kwargs.pop('boot_mode', None) or "not_set"
         self.boot_mode = AWSBootMode[bmode_str]
+        self.snapshot_tags = kwargs.pop('snapshot_tags', None)
+        self.ami_tags = kwargs.pop('ami_tags', None)
 
         super(AWSPublishingMetadata, self).__init__(*args, **kwargs)
 
@@ -558,6 +566,13 @@ class AWSService(BaseService):
         Returns:
             An EC2 Image
         """
+        def add_tags(tag_parameter_name, extra_kwargs):
+            new_tags = getattr(metadata, tag_parameter_name, None)
+            if new_tags:
+                tags = extra_kwargs.get("tags") or {}
+                new_tags.update(tags)
+                extra_kwargs.update({"tags": new_tags})
+
         log.info('Searching for image: %s', metadata.image_name)
         image = (
             self.get_image_by_name(metadata.image_name) or
@@ -578,8 +593,7 @@ class AWSService(BaseService):
 
                 # Set tags when they're provided
                 extra_kwargs = {}
-                if metadata.tags:
-                    extra_kwargs.update({"tags": metadata.tags})
+                add_tags("tags", extra_kwargs)
 
                 if not obj:
                     log.info('Object does not exist: %s', metadata.object_name)
@@ -590,6 +604,7 @@ class AWSService(BaseService):
                 else:
                     log.info('Object already exists')
 
+                add_tags("snapshot_tags", extra_kwargs)
                 snapshot = self.import_snapshot(obj,
                                                 metadata.snapshot_name,
                                                 **extra_kwargs)
@@ -765,8 +780,10 @@ class AWSService(BaseService):
             BillingProducts=metadata.billing_products,
             **optional_kwargs,
         )
-        if metadata.tags:
-            self.tag_image(image, metadata.tags)
+        if metadata.tags or metadata.ami_tags:
+            tags = metadata.tags or {}
+            tags.update(metadata.ami_tags or {})
+            self.tag_image(image, tags)
         return image
 
     def share_image(self, image, accounts=[], groups=[]):


### PR DESCRIPTION
This commit introduces two new optional properties on `AWSPublishingMetadata` named `snapshot_tags` and `ami_tags`, which when set allows to add tags just for snapshot imports or the registered image respectively.

Rationale: Currently our team is facing sporadic issues on community AMIs workflow when uploading the image to different billing types (`access` or `hourly`) after a retry, as the second attempt will look for the image name, fail to find, search for tags and find an AMI which concerns the other billing type. This was initially fixed by release-engineering/pubtools-marketplacesvm#74 by adding the billing type as tags. However, the fix brings another potential issue: we will tag everything with the billing tags, including the S3 object, which could being unecessarily uploaded twice, as well as having a tag which doesn't concern the S3 RAW object, but the snapshot/image only.

With this change on `cloudimg` we aim to provide the billing type tags just for the snapshot and AMI, leaving the S3 object with the previous ones as it shouldn't receive the billing tag.

This change also allows other teams to have a more granular control on which tags should go where.

Refers to SPSTRAT-451