### PR TITLE
AWS: Add a warning when the filter returns >1 imgs

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -237,6 +237,12 @@ class AWSService(BaseService):
 
         if not images:
             return None
+        elif len(images) > 1:
+            amis = [x['ImageId'] for x in images]
+            log.warning(
+                "Filtered more than one image: %s",
+                ", ".join(amis),
+            )
 
         return self.ec2.Image(images[0]['ImageId'])
 


### PR DESCRIPTION
The `AWSService` method `get_image_filters` expects the result to be unique, as it will blindly return the first element of the list.

This commit adds a warning to log the case which the filter didn't return a list of single image.