### PR TITLE
ci: bump codecov action and add token

### DIFF
--- a/.github/workflows/tox-test.yml
+++ b/.github/workflows/tox-test.yml
@@ -54,10 +54,11 @@ jobs:
       - name: Install pytest cov
         run: pip install pytest-cov
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v4
         with:
           fail_ci_if_error: true
           verbose: true
+          token: ${{ secrets.CODECOV_TOKEN }}
   bandit-exitzero:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Tokenless uploads via older versions of the codecov action are no longer reliable.