### PR TITLE
AWS: Add a warning when the snapshot returns >1

### DIFF
--- a/cloudimg/aws.py
+++ b/cloudimg/aws.py
@@ -372,6 +372,12 @@ class AWSService(BaseService):
 
         if not snapshots:
             return None
+        elif len(snapshots) > 1:
+            snaps = [x['SnapshotId'] for x in snapshots]
+            log.warning(
+                "Filtered more than one snapshot: %s",
+                ", ".join(snaps),
+            )
 
         return self.ec2.Snapshot(snapshots[0]['SnapshotId'])
 


### PR DESCRIPTION
The AWSService method `get_snapshot`by_name` expects the result to be unique, as it will blindly return the first element of the list.

This commit adds a warning to log the case which the filter didn't
 return a list of single snapshot.

Related to #39