### PR TITLE
PublishingMetadata: Better handling of .xz files

### DIFF
--- a/cloudimg/common.py
+++ b/cloudimg/common.py
@@ -58,7 +58,9 @@ class PublishingMetadata(object):
 
     @property
     def object_name(self):
-        return os.path.basename(self.image_path).rstrip(".xz")
+        basename = os.path.basename(self.image_path)
+        name_no_ext, ext = os.path.splitext(basename)
+        return name_no_ext if ext == ".xz" else basename
 
 
 class DeleteMetadata(object):

--- a/tests/test_aws.py
+++ b/tests/test_aws.py
@@ -44,6 +44,26 @@ class TestAWSPublishingMetadata(unittest.TestCase):
 
         self.assertEqual(metadata.snapshot_name, 'mysnapshot')
 
+    def test_object_name_correctly_parsed(self):
+        """
+        Test that ``object_name`` is correctly parsed when compressed with XZ.
+        """
+        test_cases = [
+            {"img": "image.raw", "expected": "image.raw"},
+            {"img": "image.raw.xz", "expected": "image.raw"},
+            {"img": "image.raw.zzz", "expected": "image.raw.zzz"},
+            {"img": "image.raw.zzz.xz", "expected": "image.raw.zzz"},
+            {"img": "image.raw.xz.backup", "expected": "image.raw.xz.backup"},
+        ]
+        for tc in test_cases:
+            md = AWSPublishingMetadata(
+                image_path=tc["img"],
+                image_name=tc["img"],
+                container="abcdef",
+                tags={'foo': 'bar'},
+            )
+            self.assertEqual(md.object_name, tc["expected"])
+
 
 class TestAWSService(unittest.TestCase):
 

--- a/tests/test_azure.py
+++ b/tests/test_azure.py
@@ -38,6 +38,26 @@ class TestAzurePublishingMetadata(unittest.TestCase):
                           image_name='fakeimagename',
                           container='abcdef')
 
+    def test_object_name_correctly_parsed(self):
+        """
+        Test that ``object_name`` is correctly parsed when compressed with XZ.
+        """
+        test_cases = [
+            {"img": "image.vhd", "expected": "image.vhd"},
+            {"img": "image.vhd.xz", "expected": "image.vhd"},
+            {"img": "image.vhd.zzz", "expected": "image.vhd.zzz"},
+            {"img": "image.vhd.zzz.xz", "expected": "image.vhd.zzz"},
+            {"img": "image.vhd.xz.backup", "expected": "image.vhd.xz.backup"},
+        ]
+        for tc in test_cases:
+            md = AzurePublishingMetadata(
+                image_path=tc["img"],
+                image_name=tc["img"],
+                container="abcdef",
+                tags={'foo': 'bar'},
+            )
+            self.assertEqual(md.object_name, tc["expected"])
+
 
 class TestAzureService(unittest.TestCase):
 


### PR DESCRIPTION
This commit changes the `PublishingMetadata`'s property `object_name` to safely remove the `.xz` extension instead of relying on `rstrip`.

This approach was suggested by a review bot in a similar situation, as it can be seen here:
https://github.com/release-engineering/pubtools-marketplacesvm/pull/139#discussion_r2784301605